### PR TITLE
Added a GitHub Action workflow for releasing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,43 @@
+name: Cut a new release
+
+on:
+  workflow_dispatch:
+    inputs:
+      name:
+        description: 'Please input any text for confirmation'
+        required: true
+
+jobs:
+  release:
+    needs: [clj_style, clj_kondo]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-java@v2
+        with:
+          distribution: 'zulu'
+          java-version: '11'
+          java-package: jdk
+          architecture: x64
+
+      - uses: DeLaGuardo/setup-clojure@master
+        with:
+          cli: '1.10.3.1040'
+
+      - name: Show versions
+        run: |
+          java -version
+          clojure --version
+
+      - name: Cache dependencies
+        uses: toyokumo/cache@main
+        with:
+          path: |
+            ~/.m2
+          key: clj-cache-${{ hashFiles('**/deps.edn') }}
+          restore-keys: |
+            clj-cache-
+
+      - name: Run tests
+        run: make release

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+VERSION_FILE := src/toyokumo/tools/release/version.clj
+RELEASE_OPTION := :version-file ${VERSION_FILE}
+
 .PHONY: lint
 lint:
 	cljstyle check
@@ -10,3 +13,18 @@ test:
 .PHONY: outdated
 outdated:
 	clojure -Sdeps '{:deps {com.github.liquidz/antq {:mvn/version "RELEASE"}}}' -M -m antq.core
+
+.PHONY: bump-minor-version
+bump-minor-version:
+	clojure -X toyokumo.tools.release/bump-minor-version ${RELEASE_OPTION}
+
+.PHONY: bump-major-version
+bump-major-version:
+	clojure -X toyokumo.tools.release/bump-major-version ${RELEASE_OPTION}
+
+.PHONY: release
+release:
+	git checkout main
+	git pull
+	clojure -X toyokumo.tools.release/pre-prod-deploy ${RELEASE_OPTION}
+	clojure -X toyokumo.tools.release/post-prod-deploy ${RELEASE_OPTION}

--- a/README.adoc
+++ b/README.adoc
@@ -10,7 +10,8 @@ Common operations for releasing new version.
 +
 [source,clojure]
 ----
-{:aliases {:release {:extra-deps {com.github.toyokumo/tools.release {:git/sha "..."}}
+{:aliases {:release {:extra-deps {com.github.toyokumo/tools.release {:git/tag "..."
+                                                                     :git/sha "..."}}
                      :ns-default toyokumo.tools.release}}}
 ----
 * Run task

--- a/src/toyokumo/tools/release/version.clj
+++ b/src/toyokumo/tools/release/version.clj
@@ -1,0 +1,6 @@
+;; This code was automatically modified by toyokumo/tools.release
+;; Don't rename `version` and `generated-at`
+(ns toyokumo.tools.release.version)
+
+(def version "1.0.1-SNAPSHOT")
+(def generated-at "1900-01-01T00:00:00.000Z")


### PR DESCRIPTION
As the title says.

- Added `src/toyokumo/tools/release/version.clj` to manage current version by tools.release itself.
- The Makefile task only do
  - Delete `-SNAPSHOT` from the version string and commit them
  - Create a new tag with current version string
  - Push to `main` branch
  - Fetch and switch to `develop` branch
  - Rebase changes between `main` branch
  - Bump the patch version 
  - Add -SNAPSHOT to the version string and commit them
  - Push to `develop` branch